### PR TITLE
Add https for matlab exchange for-each-iterator download

### DIFF
--- a/configurations/for-each-iterator.json
+++ b/configurations/for-each-iterator.json
@@ -11,5 +11,5 @@
 	"toolboxRoot": "",
 	"type": "webget",
 	"update": "never",
-	"url": "http:\/\/in.mathworks.com\/matlabcentral\/mlc-downloads\/downloads\/submissions\/48729\/versions\/11\/download\/zip"
+	"url": "https:\/\/in.mathworks.com\/matlabcentral\/mlc-downloads\/downloads\/submissions\/48729\/versions\/11\/download\/zip"
 }


### PR DESCRIPTION
Matlab file exchange does not support HTTP download anymore. Prefixing the download link with https.
