### PR TITLE
add URL to mgl dependency in Lab-Matlab-Control

### DIFF
--- a/configurations/Lab-Matlab-Control.json
+++ b/configurations/Lab-Matlab-Control.json
@@ -1,20 +1,21 @@
 [
 	{	
 		"name": "Lab-Matlab-Control",
-        "flavor": "stable",
-        "pathPlacement": "append",
+        	"flavor": "stable",
+        	"pathPlacement": "append",
 		"type": "git",
 		"url": "https://github.com/TheGoldLab/Lab-Matlab-Control.git"
 	},
 	{
 		"name": "Lab-Matlab-Utilities",
 		"type": "include",
-        "pathPlacement": "append"
+        	"pathPlacement": "append"
 	},
 	{
 		"name": "mgl",
-		"type": "include",
-        "pathPlacement": "append"
+		"type": "git",
+		"url": "https://github.com/justingardner/mgl.git",
+		"pathPlacement": "append"
 	},
 	{
 		"name": "mQUESTPlus",


### PR DESCRIPTION
Hi, since mgl is not directly listed in the ToolboxHub/ToolboxRegistry, I added its explicit URL in my toolbox Lab-Matlab-Control