### PR TITLE
update repository names from TheGoldLab

### DIFF
--- a/configurations/Lab_Matlab_Control.json
+++ b/configurations/Lab_Matlab_Control.json
@@ -1,13 +1,13 @@
 [
 	{	
-		"name": "Lab-Matlab-Control",
+		"name": "Lab_Matlab_Control",
         	"flavor": "stable",
         	"pathPlacement": "append",
 		"type": "git",
-		"url": "https://github.com/TheGoldLab/Lab-Matlab-Control.git"
+		"url": "https://github.com/TheGoldLab/Lab_Matlab_Control.git"
 	},
 	{
-		"name": "Lab-Matlab-Utilities",
+		"name": "Lab_Matlab_Utilities",
 		"type": "include",
         	"pathPlacement": "append"
 	},

--- a/configurations/Lab_Matlab_Utilities.json
+++ b/configurations/Lab_Matlab_Utilities.json
@@ -1,11 +1,11 @@
 [
 	{	
-		"name": "Lab-Matlab-Utilities",
+		"name": "Lab_Matlab_Utilities",
 		"pathPlacement": "append",
 		"subfolder": "",
 		"toolboxRoot": "",
 		"type": "git",
 		"update": "",
-		"url": "https://github.com/TheGoldLab/Lab-Matlab-Utilities.git"
+		"url": "https://github.com/TheGoldLab/Lab_Matlab_Utilities.git"
 	}
 ]


### PR DESCRIPTION
[TheGoldLab](https://github.com/TheGoldLab) has just implemented a new naming convention for its repositories, and I would like these changes to be reflected in your ToolboxHub/ToolboxRegistry, if possible.